### PR TITLE
feat: set minimum python version to 3.9

### DIFF
--- a/bugsy/attachment.py
+++ b/bugsy/attachment.py
@@ -3,7 +3,6 @@ import binascii
 import copy
 from datetime import datetime as dt
 
-import six
 
 from .errors import AttachmentException
 
@@ -69,16 +68,13 @@ class Attachment(object):
             if attr == "data":
                 # Attempt to decode data to ensure it's valid
                 try:
-                    if hasattr(base64, "decodebytes"):
-                        base64.decodebytes(value.encode("utf-8"))
-                    else:
-                        base64.decodestring(value)
+                    base64.decodebytes(value.encode("utf-8"))
                 except binascii.Error:
                     raise AttachmentException(
                         "The data field value must be in base64 format"
                     )
             elif attr in ["comment", "content_type", "file_name", "summary"]:
-                if not isinstance(value, six.string_types):
+                if not isinstance(value, str):
                     raise AttachmentException(
                         "The %s field value must be of type string" % attr
                     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ flake8
 pytest
 requests
 responses
-six
+setuptools
 tox

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="bugsy",
-    version="0.12.0",
+    version="0.13.0",
     description="A library for interacting Bugzilla Native REST API",
     author="David Burns",
     author_email="david.burns@theautomatedtester.co.uk",
@@ -16,7 +16,15 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Topic :: Software Development :: Libraries",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3 :: Only",
     ],
     packages=find_packages(),
+    python_requires=">=3.9",
     install_requires=["requests>=1.1.0"],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37
+envlist = py3{9,10,11,12,13}
 [testenv]
 deps = -rrequirements.txt
 commands=py.test


### PR DESCRIPTION
BREAKING CHANGE: Drops support for versions less than python 3.9